### PR TITLE
Exceptions rework

### DIFF
--- a/src/java/src/Benchmark.java
+++ b/src/java/src/Benchmark.java
@@ -77,7 +77,7 @@ public class Benchmark {
                     maxTransferLatency);
             System.out.printf("total %d transfers in %dms\n", max_batches * max_transfers_per_batch, totalTime);
 
-        } catch (InitializationException | RequestException | Exception e) {
+        } catch (Exception e) {
             System.out.println(e);
             e.printStackTrace();
         }

--- a/src/java/src/com/tigerbeetle/Account.java
+++ b/src/java/src/com/tigerbeetle/Account.java
@@ -119,6 +119,7 @@ public final class Account {
     public void setId(UUID id) {
         if (id == null)
             throw new NullPointerException();
+
         this.id = id;
     }
 

--- a/src/java/src/com/tigerbeetle/AccountsBatch.java
+++ b/src/java/src/com/tigerbeetle/AccountsBatch.java
@@ -28,25 +28,28 @@ public final class AccountsBatch extends Batch {
 
     AccountsBatch(ByteBuffer buffer)
             throws RequestException {
+
         super(buffer);
 
         final var bufferLen = buffer.capacity();
 
         // Make sure the completion handler is giving us valid data
         if (bufferLen % Account.Struct.SIZE != 0)
-            throw new RequestException(RequestException.Status.INVALID_DATA_SIZE);
+            throw new AssertionError(
+                    "Invalid data received from completion handler: bufferLen=%d, sizeOf(Account)=%d.",
+                    bufferLen,
+                    Account.Struct.SIZE);
 
         this.capacity = bufferLen / Account.Struct.SIZE;
         this.lenght = capacity;
     }
 
-    public void add(Account account)
-            throws IndexOutOfBoundsException {
+    public void add(Account account) {
         set(lenght, account);
     }
 
-    public Account get(int index)
-            throws IndexOutOfBoundsException {
+    public Account get(int index) {
+
         if (index < 0 || index >= capacity)
             throw new IndexOutOfBoundsException();
 
@@ -54,10 +57,11 @@ public final class AccountsBatch extends Batch {
         return new Account(ptr);
     }
 
-    public void set(int index, Account account)
-            throws IndexOutOfBoundsException, NullPointerException {
+    public void set(int index, Account account) {
+
         if (index < 0 || index >= capacity)
             throw new IndexOutOfBoundsException();
+
         if (account == null)
             throw new NullPointerException();
 
@@ -66,7 +70,10 @@ public final class AccountsBatch extends Batch {
         account.save(ptr);
 
         if (ptr.position() - start != Account.Struct.SIZE)
-            throw new IndexOutOfBoundsException("Unexpected account size");
+            throw new AssertionError("Unexpected position: ptr.position()=%d, start=%d, sizeOf(Account)=%d.",
+                    ptr.position(),
+                    start,
+                    Account.Struct.SIZE);
 
         if (index >= lenght)
             lenght = index + 1;
@@ -81,12 +88,12 @@ public final class AccountsBatch extends Batch {
         return this.capacity;
     }
 
-    public Account[] toArray()
-            throws BufferUnderflowException {
+    public Account[] toArray() {
         Account[] array = new Account[lenght];
         for (int i = 0; i < lenght; i++) {
             array[i] = get(i);
         }
+
         return array;
     }
 

--- a/src/java/src/com/tigerbeetle/AccountsBatch.java
+++ b/src/java/src/com/tigerbeetle/AccountsBatch.java
@@ -1,6 +1,5 @@
 package com.tigerbeetle;
 
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
 public final class AccountsBatch extends Batch {

--- a/src/java/src/com/tigerbeetle/AssertionError.java
+++ b/src/java/src/com/tigerbeetle/AssertionError.java
@@ -9,4 +9,8 @@ public final class AssertionError extends Error {
     AssertionError(String format, Object... args) {
         super(String.format(format, args));
     }
+
+    AssertionError(Throwable cause, String format, Object... args) {
+        super(String.format(format, args), cause);
+    }    
 }

--- a/src/java/src/com/tigerbeetle/AssertionError.java
+++ b/src/java/src/com/tigerbeetle/AssertionError.java
@@ -1,11 +1,6 @@
 package com.tigerbeetle;
 
-/**
- * {@code AssertionError} is a <em>unchecked exception</em>
- * that is can be thrown when any unexpected value is received by TigerBeetle.
- * This exception should be logged with full stack trace.
- */
-public final class AssertionError extends Error {
+public final class AssertionError extends java.lang.AssertionError {
     AssertionError(String format, Object... args) {
         super(String.format(format, args));
     }

--- a/src/java/src/com/tigerbeetle/AssertionError.java
+++ b/src/java/src/com/tigerbeetle/AssertionError.java
@@ -1,0 +1,12 @@
+package com.tigerbeetle;
+
+/**
+ * {@code AssertionError} is a <em>unchecked exception</em>
+ * that is can be thrown when any unexpected value is received by TigerBeetle.
+ * This exception should be logged with full stack trace.
+ */
+public final class AssertionError extends Error {
+    AssertionError(String format, Object... args) {
+        super(String.format(format, args));
+    }
+}

--- a/src/java/src/com/tigerbeetle/Client.java
+++ b/src/java/src/com/tigerbeetle/Client.java
@@ -58,7 +58,7 @@ public final class Client implements AutoCloseable {
     }
 
     public CreateAccountResult createAccount(Account account)
-            throws InterruptedException, RequestException {
+            throws RequestException {
         var batch = new AccountsBatch(1);
         batch.add(account);
 
@@ -71,7 +71,7 @@ public final class Client implements AutoCloseable {
     }
 
     public CreateAccountsResult[] createAccounts(Account[] batch)
-            throws InterruptedException, RequestException {
+            throws RequestException {
         return createAccounts(new AccountsBatch(batch));
     }
 
@@ -79,7 +79,7 @@ public final class Client implements AutoCloseable {
             throws RequestException {
         var request = new CreateAccountsRequest(this, batch);
         request.beginRequest();
-        request.waitForCompletion();
+        request.waitForCompletionUninterruptibly();
         return request.getResult();
     }
 
@@ -115,7 +115,7 @@ public final class Client implements AutoCloseable {
             throws RequestException {
         var request = new LookupAccountsRequest(this, batch);
         request.beginRequest();
-        request.waitForCompletion();
+        request.waitForCompletionUninterruptibly();
         return request.getResult();
     }
 
@@ -151,7 +151,7 @@ public final class Client implements AutoCloseable {
             throws RequestException {
         var request = new CreateTransfersRequest(this, batch);
         request.beginRequest();
-        request.waitForCompletion();
+        request.waitForCompletionUninterruptibly();
         return request.getResult();
     }
 
@@ -187,7 +187,7 @@ public final class Client implements AutoCloseable {
             throws RequestException {
         var request = new LookupTransfersRequest(this, batch);
         request.beginRequest();
-        request.waitForCompletion();
+        request.waitForCompletionUninterruptibly();
         return request.getResult();
     }
 

--- a/src/java/src/com/tigerbeetle/Client.java
+++ b/src/java/src/com/tigerbeetle/Client.java
@@ -21,22 +21,25 @@ public final class Client implements AutoCloseable {
     private long packetsTail;
 
     public Client(int clusterID, String[] replicaAddresses)
-            throws IllegalArgumentException, InitializationException {
+            throws InitializationException {
         this(clusterID, replicaAddresses, DEFAULT_MAX_CONCURRENCY);
     }
 
     public Client(int clusterID, String[] replicaAddresses, int maxConcurrency)
-            throws IllegalArgumentException, InitializationException {
+            throws InitializationException {
         if (clusterID < 0)
             throw new IllegalArgumentException("clusterID must be positive");
+
         if (replicaAddresses == null || replicaAddresses.length == 0)
             throw new IllegalArgumentException("Invalid replica addresses");
 
         // Cap the maximum amount of packets
         if (maxConcurrency <= 0)
             throw new IllegalArgumentException("Invalid maxConcurrency");
-        if (maxConcurrency > 4096)
+
+        if (maxConcurrency > 4096) {
             maxConcurrency = 4096;
+        }
 
         var joiner = new StringJoiner(",");
         for (var address : replicaAddresses) {
@@ -53,7 +56,7 @@ public final class Client implements AutoCloseable {
     }
 
     public CreateAccountResult createAccount(Account account)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         var batch = new AccountsBatch(1);
         batch.add(account);
 
@@ -66,12 +69,12 @@ public final class Client implements AutoCloseable {
     }
 
     public CreateAccountsResult[] createAccounts(Account[] batch)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         return createAccounts(new AccountsBatch(batch));
     }
 
     public CreateAccountsResult[] createAccounts(AccountsBatch batch)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         var request = new CreateAccountsRequest(this, batch);
         request.beginRequest();
         request.waitForCompletion();
@@ -79,19 +82,19 @@ public final class Client implements AutoCloseable {
     }
 
     public Future<CreateAccountsResult[]> createAccountsAsync(Account[] batch)
-            throws IllegalArgumentException, InterruptedException {
+            throws InterruptedException {
         return createAccountsAsync(new AccountsBatch(batch));
     }
 
     public Future<CreateAccountsResult[]> createAccountsAsync(AccountsBatch batch)
-            throws IllegalArgumentException, InterruptedException {
+            throws InterruptedException {
         var request = new CreateAccountsRequest(this, batch);
         request.beginRequest();
         return request;
     }
 
     public Account lookupAccount(UUID uuid)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         var batch = new UUIDsBatch(1);
         batch.Add(uuid);
 
@@ -104,12 +107,12 @@ public final class Client implements AutoCloseable {
     }
 
     public Account[] lookupAccounts(UUID[] batch)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         return lookupAccounts(new UUIDsBatch(batch));
     }
 
     public Account[] lookupAccounts(UUIDsBatch batch)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         var request = new LookupAccountsRequest(this, batch);
         request.beginRequest();
         request.waitForCompletion();
@@ -117,19 +120,19 @@ public final class Client implements AutoCloseable {
     }
 
     public Future<Account[]> lookupAccountsAsync(UUID[] batch)
-            throws IllegalArgumentException, InterruptedException {
+            throws InterruptedException {
         return lookupAccountsAsync(new UUIDsBatch(batch));
     }
 
     public Future<Account[]> lookupAccountsAsync(UUIDsBatch batch)
-            throws IllegalArgumentException, InterruptedException {
+            throws InterruptedException {
         var request = new LookupAccountsRequest(this, batch);
         request.beginRequest();
         return request;
     }
 
     public CreateTransferResult createTransfer(Transfer transfer)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         var batch = new TransfersBatch(1);
         batch.add(transfer);
 
@@ -142,12 +145,12 @@ public final class Client implements AutoCloseable {
     }
 
     public CreateTransfersResult[] createTransfers(Transfer[] batch)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         return createTransfers(new TransfersBatch(batch));
     }
 
     public CreateTransfersResult[] createTransfers(TransfersBatch batch)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         var request = new CreateTransfersRequest(this, batch);
         request.beginRequest();
         request.waitForCompletion();
@@ -155,19 +158,19 @@ public final class Client implements AutoCloseable {
     }
 
     public Future<CreateTransfersResult[]> createTransfersAsync(Transfer[] batch)
-            throws IllegalArgumentException, InterruptedException {
+            throws InterruptedException {
         return createTransfersAsync(new TransfersBatch(batch));
     }
 
     public Future<CreateTransfersResult[]> createTransfersAsync(TransfersBatch batch)
-            throws IllegalArgumentException, InterruptedException {
+            throws InterruptedException {
         var request = new CreateTransfersRequest(this, batch);
         request.beginRequest();
         return request;
     }
 
     public Transfer lookupTransfer(UUID uuid)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         var batch = new UUIDsBatch(1);
         batch.Add(uuid);
 
@@ -180,12 +183,12 @@ public final class Client implements AutoCloseable {
     }
 
     public Transfer[] lookupTransfers(UUID[] batch)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         return lookupTransfers(new UUIDsBatch(batch));
     }
 
     public Transfer[] lookupTransfers(UUIDsBatch batch)
-            throws IllegalArgumentException, InterruptedException, RequestException {
+            throws InterruptedException, RequestException {
         var request = new LookupTransfersRequest(this, batch);
         request.beginRequest();
         request.waitForCompletion();
@@ -193,19 +196,19 @@ public final class Client implements AutoCloseable {
     }
 
     public Future<Transfer[]> lookupTransfersAsync(UUID[] batch)
-            throws IllegalArgumentException, InterruptedException {
+            throws InterruptedException {
         return lookupTransfersAsync(new UUIDsBatch(batch));
     }
 
     public Future<Transfer[]> lookupTransfersAsync(UUIDsBatch batch)
-            throws IllegalArgumentException, InterruptedException {
+            throws InterruptedException {
         var request = new LookupTransfersRequest(this, batch);
         request.beginRequest();
         return request;
     }
 
     void submit(Request<?> request)
-            throws IllegalStateException, InterruptedException {
+            throws InterruptedException {
         long packet = adquirePacket();
         submit(clientHandle, request, packet);
     }
@@ -215,10 +218,12 @@ public final class Client implements AutoCloseable {
 
         // Assure that only the max number of concurrent requests can adquire a packet
         // It forces other threads to wait until a packet became available
-        // We also assure that the clientHandle will be zeroed only after all permits have been released
+        // We also assure that the clientHandle will be zeroed only after all permits
+        // have been released
         final int TIMEOUT = 5;
         do {
-            if (clientHandle == 0) throw new IllegalStateException("Client is closed");
+            if (clientHandle == 0)
+                throw new IllegalStateException("Client is closed");
         } while (!maxConcurrencySemaphore.tryAcquire(TIMEOUT, TimeUnit.MILLISECONDS));
 
         synchronized (this) {
@@ -248,7 +253,7 @@ public final class Client implements AutoCloseable {
             this.maxConcurrencySemaphore.acquireUninterruptibly(maxConcurrency);
 
             // Deinit and sinalize that this client is closed by setting the handles to 0
-            synchronized(this) {
+            synchronized (this) {
                 clientDeinit(clientHandle);
 
                 clientHandle = 0;
@@ -256,7 +261,7 @@ public final class Client implements AutoCloseable {
                 packetsTail = 0;
             }
         }
-    }    
+    }
 
     private native void submit(long clientHandle, Request<?> request, long packet);
 

--- a/src/java/src/com/tigerbeetle/CreateAccountResult.java
+++ b/src/java/src/com/tigerbeetle/CreateAccountResult.java
@@ -33,7 +33,7 @@ public enum CreateAccountResult {
     public static CreateAccountResult fromValue(int value) {
         var values = CreateAccountResult.values();
         if (value < 0 || value >= values.length)
-            throw new IllegalArgumentException(String.format("Protocol error, invalid CreateAccountResult=%d", value));
+            throw new AssertionError("Invalid CreateAccountResult: value=%d", value);
 
         return values[value];
     }

--- a/src/java/src/com/tigerbeetle/CreateAccountsRequest.java
+++ b/src/java/src/com/tigerbeetle/CreateAccountsRequest.java
@@ -2,8 +2,7 @@ package com.tigerbeetle;
 
 class CreateAccountsRequest extends Request<CreateAccountsResult> {
 
-    protected CreateAccountsRequest(Client client, AccountsBatch batch)
-            throws IllegalArgumentException {
+    protected CreateAccountsRequest(Client client, AccountsBatch batch) {
         super(client, Request.Operations.CREATE_ACCOUNTS, batch);
     }
 

--- a/src/java/src/com/tigerbeetle/CreateAccountsResultBatch.java
+++ b/src/java/src/com/tigerbeetle/CreateAccountsResultBatch.java
@@ -1,6 +1,5 @@
 package com.tigerbeetle;
 
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
 class CreateAccountsResultBatch extends Batch {
@@ -9,29 +8,31 @@ class CreateAccountsResultBatch extends Batch {
 
     public CreateAccountsResultBatch(ByteBuffer buffer)
             throws RequestException {
+
         super(buffer);
 
         final var bufferLen = buffer.capacity();
 
         // Make sure the completion handler is giving us valid data
         if (bufferLen % CreateAccountsResult.Struct.SIZE != 0)
-            throw new RequestException(RequestException.Status.INVALID_DATA_SIZE);
+            throw new AssertionError(
+                    "Invalid data received from completion handler. bufferLen=%d, sizeOf(CreateAccountsResult)=%d.",
+                    bufferLen,
+                    CreateAccountsResult.Struct.SIZE);
 
         this.lenght = bufferLen / CreateAccountsResult.Struct.SIZE;
     }
 
-    public CreateAccountsResult get(int index)
-            throws IndexOutOfBoundsException, BufferUnderflowException {
+    public CreateAccountsResult get(int index) {
         if (index < 0 || index >= lenght)
             throw new IndexOutOfBoundsException();
 
-        ByteBuffer ptr = getBuffer().position(index * CreateAccountsResult.Struct.SIZE);
+        var ptr = getBuffer().position(index * CreateAccountsResult.Struct.SIZE);
         return new CreateAccountsResult(ptr);
     }
 
-    public CreateAccountsResult[] toArray()
-            throws BufferUnderflowException {
-        CreateAccountsResult[] array = new CreateAccountsResult[lenght];
+    public CreateAccountsResult[] toArray() {
+        var array = new CreateAccountsResult[lenght];
         for (int i = 0; i < lenght; i++) {
             array[i] = get(i);
         }

--- a/src/java/src/com/tigerbeetle/CreateTransferResult.java
+++ b/src/java/src/com/tigerbeetle/CreateTransferResult.java
@@ -75,7 +75,7 @@ public enum CreateTransferResult {
     public static CreateTransferResult fromValue(int value) {
         var values = CreateTransferResult.values();
         if (value < 0 || value >= values.length)
-            throw new IllegalArgumentException(String.format("Protocol error, invalid CreateTransferResult=%d", value));
+            throw new AssertionError("Invalid CreateTransferResult: value=%d", value);
 
         return values[value];
     }

--- a/src/java/src/com/tigerbeetle/CreateTransfersRequest.java
+++ b/src/java/src/com/tigerbeetle/CreateTransfersRequest.java
@@ -2,8 +2,7 @@ package com.tigerbeetle;
 
 class CreateTransfersRequest extends Request<CreateTransfersResult> {
 
-    protected CreateTransfersRequest(Client client, TransfersBatch batch)
-            throws IllegalArgumentException {
+    protected CreateTransfersRequest(Client client, TransfersBatch batch) {
         super(client, Request.Operations.CREATE_TRANSFERS, batch);
     }
 

--- a/src/java/src/com/tigerbeetle/CreateTransfersResultBatch.java
+++ b/src/java/src/com/tigerbeetle/CreateTransfersResultBatch.java
@@ -1,6 +1,5 @@
 package com.tigerbeetle;
 
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
 class CreateTransfersResultBatch extends Batch {
@@ -15,13 +14,15 @@ class CreateTransfersResultBatch extends Batch {
 
         // Make sure the completion handler is giving us valid data
         if (bufferLen % CreateTransfersResult.Struct.SIZE != 0)
-            throw new RequestException(RequestException.Status.INVALID_DATA_SIZE);
+            throw new AssertionError(
+                    "Invalid data received from completion handler. bufferLen=%d, sizeOf(CreateTransfersResult)=%d.",
+                    bufferLen, 
+                    CreateTransfersResult.Struct.SIZE);
 
         this.lenght = bufferLen / CreateTransfersResult.Struct.SIZE;
     }
 
-    public CreateTransfersResult get(int index)
-            throws IndexOutOfBoundsException, BufferUnderflowException {
+    public CreateTransfersResult get(int index) {
         if (index < 0 || index >= lenght)
             throw new IndexOutOfBoundsException();
 
@@ -29,8 +30,7 @@ class CreateTransfersResultBatch extends Batch {
         return new CreateTransfersResult(ptr);
     }
 
-    public CreateTransfersResult[] toArray()
-            throws BufferUnderflowException {
+    public CreateTransfersResult[] toArray() {
         var array = new CreateTransfersResult[lenght];
         for (int i = 0; i < lenght; i++) {
             array[i] = get(i);
@@ -41,7 +41,7 @@ class CreateTransfersResultBatch extends Batch {
     @Override
     public int getLenght() {
         return lenght;
-    }    
+    }
 
     @Override
     public long getBufferLen() {

--- a/src/java/src/com/tigerbeetle/InitializationException.java
+++ b/src/java/src/com/tigerbeetle/InitializationException.java
@@ -1,6 +1,6 @@
 package com.tigerbeetle;
 
-public final class InitializationException extends Throwable {
+public final class InitializationException extends Exception {
 
     public static final class Status {
         public static final int SUCCESS = 0;

--- a/src/java/src/com/tigerbeetle/InitializationException.java
+++ b/src/java/src/com/tigerbeetle/InitializationException.java
@@ -1,6 +1,6 @@
 package com.tigerbeetle;
 
-public final class InitializationException extends Exception {
+public final class InitializationException extends RuntimeException {
 
     public static final class Status {
         public static final int SUCCESS = 0;

--- a/src/java/src/com/tigerbeetle/LookupAccountsRequest.java
+++ b/src/java/src/com/tigerbeetle/LookupAccountsRequest.java
@@ -2,8 +2,7 @@ package com.tigerbeetle;
 
 class LookupAccountsRequest extends Request<Account> {
 
-    protected LookupAccountsRequest(Client client, UUIDsBatch batch)
-            throws IllegalArgumentException {
+    protected LookupAccountsRequest(Client client, UUIDsBatch batch) {
         super(client, Request.Operations.LOOKUP_ACCOUNTS, batch);
     }
 

--- a/src/java/src/com/tigerbeetle/LookupTransfersRequest.java
+++ b/src/java/src/com/tigerbeetle/LookupTransfersRequest.java
@@ -2,8 +2,7 @@ package com.tigerbeetle;
 
 class LookupTransfersRequest extends Request<Transfer> {
 
-    protected LookupTransfersRequest(Client client, UUIDsBatch batch)
-            throws IllegalArgumentException {
+    protected LookupTransfersRequest(Client client, UUIDsBatch batch) {
         super(client, Request.Operations.LOOKUP_TRANSFERS, batch);
     }
 

--- a/src/java/src/com/tigerbeetle/RequestException.java
+++ b/src/java/src/com/tigerbeetle/RequestException.java
@@ -1,6 +1,6 @@
 package com.tigerbeetle;
 
-public final class RequestException extends Throwable {
+public final class RequestException extends Exception {
 
     public final static class Status {
         public final static byte OK = 0;

--- a/src/java/src/com/tigerbeetle/Transfer.java
+++ b/src/java/src/com/tigerbeetle/Transfer.java
@@ -61,6 +61,7 @@ public final class Transfer {
     public void setId(UUID id) {
         if (id == null)
             throw new NullPointerException();
+
         this.id = id;
     }
 
@@ -71,6 +72,7 @@ public final class Transfer {
     public void setDebitAccountId(UUID debitAccountId) {
         if (debitAccountId == null)
             throw new NullPointerException();
+
         this.debitAccountId = debitAccountId;
     }
 
@@ -81,6 +83,7 @@ public final class Transfer {
     public void setCreditAccountId(UUID creditAccountId) {
         if (creditAccountId == null)
             throw new NullPointerException();
+
         this.creditAccountId = creditAccountId;
     }
 

--- a/src/java/src/com/tigerbeetle/TransfersBatch.java
+++ b/src/java/src/com/tigerbeetle/TransfersBatch.java
@@ -28,25 +28,27 @@ public final class TransfersBatch extends Batch {
 
     TransfersBatch(ByteBuffer buffer)
             throws RequestException {
+
         super(buffer);
 
         final var bufferLen = buffer.capacity();
 
         // Make sure the completion handler is giving us valid data
         if (bufferLen % Transfer.Struct.SIZE != 0)
-            throw new RequestException(RequestException.Status.INVALID_DATA_SIZE);
+            throw new AssertionError(
+                    "Invalid data received from completion handler: bufferLen=%d, sizeOf(Transfer)=%d.",
+                    bufferLen,
+                    Transfer.Struct.SIZE);
 
         this.capacity = bufferLen / Transfer.Struct.SIZE;
         this.lenght = capacity;
     }
 
-    public void add(Transfer transfer)
-            throws IndexOutOfBoundsException {
+    public void add(Transfer transfer) {
         set(lenght, transfer);
     }
 
-    public Transfer get(int index)
-            throws IndexOutOfBoundsException, BufferUnderflowException {
+    public Transfer get(int index) {
         if (index < 0 || index >= capacity)
             throw new IndexOutOfBoundsException();
 
@@ -54,10 +56,10 @@ public final class TransfersBatch extends Batch {
         return new Transfer(ptr);
     }
 
-    public void set(int index, Transfer transfer)
-            throws IndexOutOfBoundsException, NullPointerException {
+    public void set(int index, Transfer transfer) {
         if (index < 0 || index >= capacity)
             throw new IndexOutOfBoundsException();
+
         if (transfer == null)
             throw new NullPointerException();
 
@@ -66,7 +68,10 @@ public final class TransfersBatch extends Batch {
         transfer.save(ptr);
 
         if (ptr.position() - start != Transfer.Struct.SIZE)
-            throw new IndexOutOfBoundsException("Unexpected account size");
+            throw new AssertionError("Unexpected position: ptr.position()=%d, start=%d, sizeOf(Transfer)=%d.",
+                    ptr.position(),
+                    start,
+                    Account.Struct.SIZE);
 
         if (index >= lenght)
             lenght = index + 1;
@@ -81,8 +86,7 @@ public final class TransfersBatch extends Batch {
         return this.capacity;
     }
 
-    public Transfer[] toArray()
-            throws BufferUnderflowException {
+    public Transfer[] toArray() {
         var array = new Transfer[lenght];
         for (int i = 0; i < lenght; i++) {
             array[i] = get(i);

--- a/src/java/src/com/tigerbeetle/TransfersBatch.java
+++ b/src/java/src/com/tigerbeetle/TransfersBatch.java
@@ -1,6 +1,5 @@
 package com.tigerbeetle;
 
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
 public final class TransfersBatch extends Batch {

--- a/src/java/src/com/tigerbeetle/UUIDsBatch.java
+++ b/src/java/src/com/tigerbeetle/UUIDsBatch.java
@@ -1,6 +1,5 @@
 package com.tigerbeetle;
 
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 

--- a/src/java/src/com/tigerbeetle/UUIDsBatch.java
+++ b/src/java/src/com/tigerbeetle/UUIDsBatch.java
@@ -39,19 +39,19 @@ public class UUIDsBatch extends Batch {
 
         // Make sure the completion handler is giving us valid data
         if (bufferLen % Struct.SIZE != 0)
-            throw new RequestException(RequestException.Status.INVALID_DATA_SIZE);
+            throw new AssertionError("Invalid data received from completion handler. bufferLen=%d, sizeOf(UUID)=%d.",
+                    bufferLen,
+                    Struct.SIZE);
 
         this.capacity = bufferLen / Struct.SIZE;
         this.lenght = capacity;
     }
 
-    public void Add(UUID uuid)
-            throws IndexOutOfBoundsException {
+    public void Add(UUID uuid) {
         Set(lenght, uuid);
     }
 
-    public UUID Get(int index)
-            throws IndexOutOfBoundsException, BufferUnderflowException {
+    public UUID Get(int index) {
         if (index < 0 || index >= capacity)
             throw new IndexOutOfBoundsException();
 
@@ -59,10 +59,10 @@ public class UUIDsBatch extends Batch {
         return uuidFromBuffer(ptr);
     }
 
-    public void Set(int index, UUID uuid)
-            throws IndexOutOfBoundsException, NullPointerException {
+    public void Set(int index, UUID uuid) {
         if (index < 0 || index >= capacity)
             throw new IndexOutOfBoundsException();
+
         if (uuid == null)
             throw new NullPointerException();
 
@@ -74,7 +74,11 @@ public class UUIDsBatch extends Batch {
                 .putLong(uuid.getMostSignificantBits());
 
         if (ptr.position() - start != Struct.SIZE)
-            throw new IndexOutOfBoundsException("Unexpected account size");
+            throw new AssertionError("Unexpected position: ptr.position()=%d, start=%d, sizeOf(UUID)=%d.",
+                    ptr.position(),
+                    start,
+                    Struct.SIZE);
+
         if (index >= lenght)
             lenght = index + 1;
     }
@@ -88,8 +92,7 @@ public class UUIDsBatch extends Batch {
         return this.capacity;
     }
 
-    public UUID[] toArray()
-            throws BufferUnderflowException {
+    public UUID[] toArray() {
         var array = new UUID[lenght];
         for (int i = 0; i < lenght; i++) {
             array[i] = Get(i);

--- a/src/java/tests/com/tigerbeetle/IntegrationTest.java
+++ b/src/java/tests/com/tigerbeetle/IntegrationTest.java
@@ -431,17 +431,12 @@ public class IntegrationTest {
                 // Closes the server, disconnecting the client
                 server.close();
 
-                try {
-                    // Client will submit a request, but it is not going to complete
-                    @SuppressWarnings("unused")
-                    var accounts = client.lookupAccounts(new UUID[] { account1.getId(), account2.getId() });
+                // Client will submit a request, but it is not going to complete
+                @SuppressWarnings("unused")
+                var accounts = client.lookupAccounts(new UUID[] { account1.getId(), account2.getId() });
 
-                    // It is not expceted to lookupAccounts to finish
-                    Assert.assertTrue(false);
-
-                } catch (InterruptedException timeout) {
-                    Assert.assertTrue(true);
-                }
+                // It is not expceted to lookupAccounts to finish
+                Assert.assertTrue(false);
 
             } catch (Throwable any) {
                 throw any;

--- a/src/java/tests/com/tigerbeetle/UUIDBatchTest.java
+++ b/src/java/tests/com/tigerbeetle/UUIDBatchTest.java
@@ -1,7 +1,6 @@
 package com.tigerbeetle;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;


### PR DESCRIPTION
Java has 3 semantics for exceptions:

- Checked exceptions, that must be declared on the "throws" block and are required to be explicitly handled by the user, who must decide how to recover from.

- RuntimeExceptions, that can occur somehow due to unexpected runtime values and may be caught on the site or bubbled up to the caller

- Errors, that have similar semantics to "panic", and denote that there is no possible way to recover from.

This PR removes a lot of exceptions wrongly declared on the "throws" block and assures that we are following the correct semantics in exceptions we throw in our public API.