### PR TITLE
C client update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/zig-java/jui.git
 [submodule "src/zig/lib/tigerbeetle"]
 	path = src/zig/lib/tigerbeetle
-	url = https://github.com/coilhq/tigerbeetle.git
+	url = https://github.com/tigerbeetledb/tigerbeetle.git


### PR DESCRIPTION
- Updates the submodule path (still had coilhq reference in the name).

- Minor changes due to https://github.com/tigerbeetledb/tigerbeetle/pull/237, adjusting `tb_packet_t` field types to reflect C header.

- Removes the trailing `.` from all of the log messages.